### PR TITLE
feat(ci): Day04 gitleaks + Day05 harness rollout

### DIFF
--- a/.github/workflows/gitleaks-pr-scan.yml
+++ b/.github/workflows/gitleaks-pr-scan.yml
@@ -1,0 +1,13 @@
+name: Gitleaks PR Secret Scan
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    uses: clouddrove/github-shared-workflows/.github/workflows/gitleaks-pr-scan.yml@1754bbe224200aa1d820cdf795d42de54b34245f
+    secrets: inherit

--- a/.github/workflows/module-test-harness.yml
+++ b/.github/workflows/module-test-harness.yml
@@ -1,0 +1,15 @@
+name: Module Test Harness
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  complete-example:
+    uses: clouddrove/github-shared-workflows/.github/workflows/stf-checks.yml@bd958ead76ac7c72acf4976c244c47eef89c84f7
+    with:
+      provider: digitalocean
+      working_directory: ./terraform/sandbox/


### PR DESCRIPTION
Project #2 rollout update:
- Day 04: add dedicated gitleaks PR scan workflow
- Day 05: ensure module test harness is present (where missing)

Policy: reusable workflow source is clouddrove/github-shared-workflows only.