### PR TITLE
fix(ci): restore terraform workflow by using pinned shared tf-workflow

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   prod:
-    uses: clouddrove/github-shared-workflows/.github/workflows/terraform_workflow.yml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-workflow.yml@1754bbe224200aa1d820cdf795d42de54b34245f
     with:
         provider: digitalocean
         working_directory: terraform/sandbox/blr1 # Specify terraform code directory in repo


### PR DESCRIPTION
## Summary
- replace invalid reusable workflow reference `terraform_workflow.yml@master`
- switch to `tf-workflow.yml` from `clouddrove/github-shared-workflows`
- pin to commit `1754bbe224200aa1d820cdf795d42de54b34245f`

## Why
Default-branch CI started failing with a workflow resolution error because `terraform_workflow.yml` no longer exists in the shared workflows repository.

## Validation
- workflow path now points to an existing reusable workflow
- no module source code changes