### PR TITLE
feat: rollout on smurf stf checks

### DIFF
--- a/.github/workflows/tf-checks.yml
+++ b/.github/workflows/tf-checks.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   complete-do-module:
-    uses: clouddrove/github-shared-workflows/.github/workflows/stf-checks.yml@e075b2c8f7a739fc1f2a0d13133abd16c943dec2
+    uses: clouddrove/github-shared-workflows/.github/workflows/stf-checks.yml@c615ea7ef3e5beba98a335bf9acce8e67e03c755
     with:
       provider: digitalocean
       working_directory: './terraform/sandbox/blr1/'


### PR DESCRIPTION
- Rolls out Smurf STF checks for the Smurf CLI in the Terraform DigitalOcean repository
- Updates the shared STF workflow reference from
- 88efd7724e007c8f721a219498be29e0c9ad471b → c615ea7ef3e5beba98a335bf9acce8e67e03c755
- Pins the workflow to the referenced commit to ensure stable and reproducible CI runs